### PR TITLE
Add joining page, and link from README

### DIFF
--- a/JOINING.md
+++ b/JOINING.md
@@ -1,0 +1,53 @@
+# Joining CDDO on GitHub
+
+There are now separate organisations on GitHub for the Government Digital Service (GDS) and the Central Digital and Data Office (CDDO).
+
+The organisations are:
+
+- [Government Digital Service](https://github.com/alphagov) (also known as alphagov)
+- [Cabinet Office Central Digital and Data Office](https://github.com/co-cddo) (also known as co-cddo)
+
+This is to make it simpler to manage access between and across our two offices.
+
+If you work in CDDO and use GitHub, you should join CDDO’s organisation on GitHub.
+
+## Join the CDDO organisation on GitHub
+
+You can use the [Cabinet Office GitHub Enterprise page](https://github.com/enterprises/government-digital-service) to find out which GitHub organisations you’re a member of.
+
+To join CDDO’s organisation on GitHub, you must:
+
+- be in CDDO
+- have an existing or new GitHub account
+
+Before you can join, you must:
+
+- [set up multi-factor authentication (MFA)](https://docs.github.com/en/authentication/securing-your-account-with-two-factor-authentication-2fa/configuring-two-factor-authentication)
+- [add your digital.cabinet-office.gov.uk email address](https://docs.github.com/en/get-started/signing-up-for-github/verifying-your-email-address) as your GitHub account’s primary or additional email address
+- [verify your email address](https://docs.github.com/en/get-started/signing-up-for-github/verifying-your-email-address)
+
+Ask to become a member of CDDO’s organisation on GitHub by either:
+
+- posting a message on the #cddo-github Slack channel
+- emailing [co-cddo-github-admin@digital.cabinet-office.gov.uk](mailto:co-cddo-github-admin@digital.cabinet-office.gov.uk)
+
+If you were already a member of the GDS organisation, you’ll remain a member for now.
+
+## Transferring a repository from GDS to CDDO
+
+Find out how to [transfer a repository](https://docs.github.com/en/repositories/creating-and-managing-repositories/transferring-a-repository) on GitHub’s website.
+
+Some teams have already transferred their repositories. For example, the Data Standards Authority team have moved their [open-standards](https://github.com/co-cddo/open-standards) and [Federated API Discovery Model](https://github.com/co-cddo/federated-api-model) repositories from GDS to CDDO.
+
+There’s no deadline for transferring a repository from GDS to CDDO.
+
+## Creating a new repository
+
+If you’re a CDDO staff member, you must create new repositories under the CDDO organisation.
+
+You must follow the guidance on:
+
+- [storing source code](https://gds-way.cloudapps.digital/standards/source-code.html#publish-open-source-code) from The GDS Way
+- [making source code open and reusable](https://www.gov.uk/service-manual/technology/making-source-code-open-and-reusable) from the Service Manual
+
+Give your new repository a name that fully describes what it is, for example aws-route53-parked-govuk-domain.

--- a/profile/README.md
+++ b/profile/README.md
@@ -2,6 +2,9 @@
 
 CDDO leads the Digital, Data and Technology (DDaT) function for government, and is part of the Cabinet Office.
 
-You can [read more about what CDDO do here](https://www.gov.uk/government/organisations/central-digital-and-data-office/about).
+You can read more about:
+
+- [what CDDO do](https://www.gov.uk/government/organisations/central-digital-and-data-office/about)
+- [joining CDDO’s organisation on GitHub](JOINING.md)
 
 ![Twitter Follow](https://img.shields.io/twitter/follow/cabinetofficeuk?style=social)


### PR DESCRIPTION
This adds documentation on joining CDDO's organisation on GitHub, and a link from the README doc.